### PR TITLE
implement caching with a read-through conn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+SHELL := bash
+.SHELLFLAGS := -euo pipefail -c
+.ONESHELL:        # use a single shell for commands instead a new shell per line
+.DELETE_ON_ERROR: # delete output files when make rule fails
+MAKEFLAGS += --warn-undefined-variables
+MAKEFLAGS += --no-builtin-rules
+
+.PHONY: all
+all: test lint
+
+.PHONY: test
+test:
+	go test
+
+.PHONY: lint
+lint:
+	golangci-lint run

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,14 +1,9 @@
 package dns
 
 import (
-	"context"
-	"errors"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
-	"net/http/httptest"
-	"net/http/httptrace"
 	"net/netip"
 	"testing"
 	"time"
@@ -16,222 +11,40 @@ import (
 	"golang.org/x/net/dns/dnsmessage"
 )
 
-const (
-	host     = "test-cache.example.com"
-	wantBody = "ok - test cache"
-)
-
 func TestCache(t *testing.T) {
-	ctx := t.Context()
-
-	// We need a test http server that the resolver will resolve host to the
-	// local httpServer addr.
-	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(wantBody))
-	}))
-	defer httpServer.Close()
-	httpAddr := httpServer.Listener.Addr().String()
-	httpHost, httpPort, err := net.SplitHostPort(httpAddr)
-	if err != nil {
-		t.Fatalf("net.SplitHostPort: %v", err)
-	}
-	httpIPAddr, err := netip.ParseAddr(httpHost)
-	if err != nil {
-		t.Fatalf("netip.ParseAddr: %v", err)
-	}
-	t.Logf("http test server: %s:%s", httpHost, httpPort)
-
-	var dnsDoneInfo httptrace.DNSDoneInfo
-	ctx = httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
-		GotConn: func(info httptrace.GotConnInfo) {
-			t.Logf("GotConn: %v", info.Conn.RemoteAddr().String())
-		},
-		DNSStart: func(info httptrace.DNSStartInfo) {
-			t.Logf("DNS Start: host=%s", info.Host)
-		},
-		DNSDone: func(info httptrace.DNSDoneInfo) {
-			t.Logf("DNSDone: addrs=%v", info.Addrs)
-			dnsDoneInfo = info
-		},
-		ConnectStart: func(network, addr string) {
-			t.Logf("ConnectStart: network=%s, addr=%s", network, addr)
-		},
-		ConnectDone: func(network, addr string, err error) {
-			t.Logf("ConnectDone:  network=%s, addr=%s, err=%v", network, addr, err)
-		},
-	})
+	ctx, getResolvedAddrs := captureResolvedAddrs(t, t.Context())
+	fakeHTTP, fakeDNS := startServers(t, "test-cache.example.com")
 
 	cache := &Cache{
-		Dial: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			t.Logf("dial fake dns server: %s", network)
-			fakeDNS := newFakeDNSARecord(host, httpIPAddr)
-			return fakeDNS.DialContext(ctx, network, addr)
-		},
-	}
-	transport := &http.Transport{
-		DialContext: (&net.Dialer{
-			Timeout:  1 * time.Second,
-			Resolver: cache.Resolver(),
-		}).DialContext,
+		Dial: fakeDNS.DialContext,
 	}
 	client := &http.Client{
-		Transport: transport,
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+host+":"+httpPort, nil)
-	if err != nil {
-		t.Fatalf("http.NewRequest: %v", err)
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		t.Fatalf("client.Get: %v", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("client.Get: expected status %d, got %d", http.StatusOK, resp.StatusCode)
-	}
-	gotBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("read response body: %v", err)
-	}
-	if string(gotBody) != wantBody {
-		t.Fatalf("expected body %q, got %q", wantBody, gotBody)
-	}
-	if dnsDoneInfo.Err != nil {
-		t.Fatalf("DNSDoneInfo.Err: %v", dnsDoneInfo.Err)
-	}
-	if len(dnsDoneInfo.Addrs) == 0 {
-		t.Fatalf("DNSDoneInfo.Addrs empty: want %v", httpIPAddr.String())
-	}
-	if len(dnsDoneInfo.Addrs) != 1 && dnsDoneInfo.Addrs[0].String() != httpIPAddr.String() {
-		t.Fatalf("DNSDoneInfo.Addrs.len: want %v, got %v", httpIPAddr.String(), dnsDoneInfo.Addrs)
-	}
-}
-
-// newFakeDNSARecord returns a fake DNS server that responds to A record queries
-// for host with the given IP address.
-func newFakeDNSARecord(host string, ip netip.Addr) *fakeDNSServer {
-	fakeDNS := &fakeDNSServer{
-		rh: func(n, _ string, q dnsmessage.Message, _ time.Time) (dnsmessage.Message, error) {
-			r := dnsmessage.Message{
-				Header: dnsmessage.Header{
-					ID:       q.Header.ID,
-					Response: true,
-					RCode:    dnsmessage.RCodeSuccess,
-				},
-				Questions: q.Questions,
-			}
-			fqdn := dnsmessage.MustNewName(host + ".")
-			if len(q.Questions) == 1 &&
-				q.Questions[0].Type == dnsmessage.TypeA &&
-				q.Questions[0].Class == dnsmessage.ClassINET &&
-				fqdn == q.Questions[0].Name {
-				r.Answers = []dnsmessage.Resource{
-					{
-						Header: dnsmessage.ResourceHeader{
-							Name:   q.Questions[0].Name,
-							Type:   dnsmessage.TypeA,
-							Class:  dnsmessage.ClassINET,
-							Length: 4,
-						},
-						Body: &dnsmessage.AResource{
-							A: ip.As4(),
-						},
-					},
-				}
-			}
-
-			return r, nil
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout:  1 * time.Second,
+				Resolver: cache.Resolver(),
+			}).DialContext,
 		},
 	}
-	return fakeDNS
-}
 
-type fakeDNSServer struct {
-	rh        func(n, s string, q dnsmessage.Message, t time.Time) (dnsmessage.Message, error)
-	alwaysTCP bool
-}
-
-func (server *fakeDNSServer) DialContext(_ context.Context, n, s string) (net.Conn, error) {
-	if server.alwaysTCP || n == "tcp" || n == "tcp4" || n == "tcp6" {
-		return &fakeDNSConn{tcp: true, server: server, n: n, s: s}, nil
-	}
-	return &fakeDNSPacketConn{fakeDNSConn: fakeDNSConn{tcp: false, server: server, n: n, s: s}}, nil
-}
-
-type fakeDNSConn struct {
-	net.Conn
-	tcp    bool
-	server *fakeDNSServer
-	n      string
-	s      string
-	q      dnsmessage.Message
-	t      time.Time
-	buf    []byte
-}
-
-func (f *fakeDNSConn) Close() error {
-	return nil
-}
-
-func (f *fakeDNSConn) Read(b []byte) (int, error) {
-	if len(f.buf) > 0 {
-		n := copy(b, f.buf)
-		f.buf = f.buf[n:]
-		return n, nil
-	}
-
-	resp, err := f.server.rh(f.n, f.s, f.q, f.t)
+	err := doGetRequest(ctx, client, fakeHTTP.URI)
 	if err != nil {
-		return 0, err
+		t.Fatalf("doGetRequest: %v", err)
 	}
 
-	bb := make([]byte, 2, 514)
-	bb, err = resp.AppendPack(bb)
+	want := []netip.Addr{fakeHTTP.IP}
+	got := getResolvedAddrs()
+	assertSameAddrs(t, want, got)
+
+	// Second request should use the cache.
+	// Error out on the DNS request to ensure it's not called.
+	fakeDNS.handler = func(network string, q dnsmessage.Message) (dnsmessage.Message, error) {
+		return dnsmessage.Message{}, fmt.Errorf("should not be called")
+	}
+	err = doGetRequest(ctx, client, fakeHTTP.URI)
 	if err != nil {
-		return 0, fmt.Errorf("cannot marshal DNS message: %w", err)
+		t.Fatalf("doGetRequest: %v", err)
 	}
-
-	if f.tcp {
-		l := len(bb) - 2
-		bb[0] = byte(l >> 8)
-		bb[1] = byte(l)
-		f.buf = bb
-		return f.Read(b)
-	}
-
-	bb = bb[2:]
-	if len(b) < len(bb) {
-		return 0, errors.New("read would fragment DNS message")
-	}
-
-	copy(b, bb)
-	return len(bb), nil
-}
-
-func (f *fakeDNSConn) Write(b []byte) (int, error) {
-	if f.tcp && len(b) >= 2 {
-		b = b[2:]
-	}
-	if f.q.Unpack(b) != nil {
-		return 0, fmt.Errorf("cannot unmarshal DNS message fake %s (%d)", f.n, len(b))
-	}
-	return len(b), nil
-}
-
-func (f *fakeDNSConn) SetDeadline(t time.Time) error {
-	f.t = t
-	return nil
-}
-
-type fakeDNSPacketConn struct {
-	net.PacketConn
-	fakeDNSConn
-}
-
-func (f *fakeDNSPacketConn) SetDeadline(t time.Time) error {
-	return f.fakeDNSConn.SetDeadline(t)
-}
-
-func (f *fakeDNSPacketConn) Close() error {
-	return f.fakeDNSConn.Close()
+	got = getResolvedAddrs()
+	assertSameAddrs(t, want, got)
 }

--- a/conn.go
+++ b/conn.go
@@ -1,0 +1,234 @@
+package dns
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+var (
+	_ net.Conn       = (*cacheConn)(nil)
+	_ net.PacketConn = (*cacheConn)(nil)
+)
+
+// cacheConn is a read-through cache implementing net.Conn.
+// Parses DNS requests, and returns cached DNS responses on cache hit.
+// On a cache miss, delegates to a real conn and caches the results.
+type cacheConn struct {
+	// realConn is the real network connection. Initialized on the first (only)
+	// write on a cache miss.
+	realConn net.Conn
+	// questionCache is the DNS cache.
+	questionCache QuestionCache
+	// dial creates realConn on a cache miss.
+	dial func() (net.Conn, error)
+	// cachedResp is the cached DNS response. Nil until the first write. Never set
+	// on a cache miss.
+	cachedResp *bytes.Reader
+	// realResp is the DNS response from the real connection. Incrementally
+	// written by Read calls and stored in the cache on Close.
+	// Not used on a cache hit. Nil until the first Read.
+	realResp []byte
+}
+
+func (c *cacheConn) Read(b []byte) (int, error) {
+	if c.cachedResp != nil {
+		return c.cachedResp.Read(b)
+	}
+
+	// Unreachable. We always set realConn on a cache miss.
+	if c.realConn == nil {
+		return 0, fmt.Errorf("read from conn on cache miss without a real connection")
+	}
+
+	// Cache miss. Read from the real connection and store the response so we can
+	// cache it on Close.
+	n, err := c.realConn.Read(b)
+	if err != nil {
+		return n, err
+	}
+	c.realResp = append(c.realResp, b[:n]...)
+	return n, err
+}
+
+func (c *cacheConn) ReadFrom([]byte) (n int, addr net.Addr, err error) {
+	return 0, nil, fmt.Errorf("cacheConn ReadFrom not implemented")
+}
+
+func (c *cacheConn) Write(b []byte) (n int, err error) {
+	// Parse the DNS request to see if we have a cached answer.
+	msg := &dnsmessage.Message{}
+	if err := msg.Unpack(b); err != nil {
+		return 0, fmt.Errorf("unpack dns message to check cache: %w", err)
+	}
+
+	// Only support a single question for simplicity.
+	if len(msg.Questions) != 1 {
+		c.realConn, err = c.dial()
+		if err != nil {
+			return 0, fmt.Errorf("dial conn for dns cache with multiple questions: %w", err)
+		}
+		return c.realConn.Write(b)
+	}
+	q := msg.Questions[0]
+
+	// Only support A and AAAA records for simplicity.
+	if q.Type != dnsmessage.TypeA && q.Type != dnsmessage.TypeAAAA {
+		c.realConn, err = c.dial()
+		if err != nil {
+			return 0, fmt.Errorf("dial conn for dns cache with unsupported type %s: %w", q.Type, err)
+		}
+	}
+
+	answer, ok := c.questionCache.Get(newQuestion(q))
+	// Cache miss. Delegate to the real connection.
+	if !ok {
+		c.realConn, err = c.dial()
+		if err != nil {
+			return 0, fmt.Errorf("dial conn for dns cache on cache miss: %w", err)
+		}
+		return c.realConn.Write(b)
+	}
+
+	// Cache hit. Store the complete, packed DNS response for Read calls.
+	// The Go implementation of dnsPacketRoundTrip uses a single Write call.
+	msg.Answers, err = buildAnswers(q, answer)
+	if err != nil {
+		return 0, fmt.Errorf("build answers for dns cache on cache hit: %w", err)
+	}
+	msg.Response = true
+	packed, err := msg.Pack()
+	if err != nil {
+		return 0, fmt.Errorf("pack dns message for dns cache on cache hit: %w", err)
+	}
+	c.cachedResp = bytes.NewReader(packed)
+
+	return len(b), nil
+}
+
+func (c *cacheConn) WriteTo([]byte, net.Addr) (n int, err error) {
+	return 0, fmt.Errorf("cacheConn WriteTo not implemented")
+}
+
+// buildAnswers returns the DNS answers for a question from the cached Answer.
+func buildAnswers(q dnsmessage.Question, answer Answer) ([]dnsmessage.Resource, error) {
+	answers := make([]dnsmessage.Resource, 0, len(answer.IPs))
+	for _, ip := range answer.IPs {
+		// The cached IP address must match the requested type since the cache key,
+		// a Question, includes the type.
+		if q.Type == dnsmessage.TypeA && !ip.Is4() {
+			return nil, fmt.Errorf("cached IP address %s is not the correct type for dns A record for host %s", ip, q.Name.String())
+		}
+		if q.Type == dnsmessage.TypeAAAA && !ip.Is6() {
+			return nil, fmt.Errorf("cached IP address %s is not the correct type for dns AAAA record for host %s", ip, q.Name.String())
+		}
+
+		resource := dnsmessage.Resource{
+			Header: dnsmessage.ResourceHeader{
+				Name:  q.Name,
+				Type:  q.Type,
+				Class: q.Class,
+				TTL:   uint32(answer.TTL / time.Second), //nolint:gosec
+			},
+		}
+		switch {
+		case q.Type == dnsmessage.TypeA:
+			resource.Body = &dnsmessage.AResource{A: ip.As4()}
+		case q.Type == dnsmessage.TypeAAAA:
+			resource.Body = &dnsmessage.AAAAResource{AAAA: ip.As16()}
+		default:
+			return nil, fmt.Errorf("unsupported record type: %v", q.Type)
+		}
+		answers = append(answers, resource)
+	}
+
+	return answers, nil
+}
+
+func (c *cacheConn) Close() (mErr error) {
+	// Cache hit, nothing to do.
+	if c.realConn == nil {
+		return nil
+	}
+
+	// Always close the conn.
+	defer capture(&mErr, c.realConn.Close, "close real conn")
+
+	// Cache miss, but we didn't get response. Network error?
+	if len(c.realResp) == 0 {
+		return nil
+	}
+
+	// Cache miss. Store the response in the cache.
+	msg := &dnsmessage.Message{}
+	if err := msg.Unpack(c.realResp); err != nil {
+		return fmt.Errorf("unpack response to cache on close: %w", err)
+	}
+
+	// Only support a single question for simplicity.
+	if len(msg.Questions) != 1 {
+		return nil
+	}
+
+	// Store the response in the cache.
+	question := newQuestion(msg.Questions[0])
+	answer, err := newAnswer(msg)
+	if err != nil {
+		return fmt.Errorf("build new answer to cache on close: %w", err)
+	}
+	if !answer.IsExpired() {
+		c.questionCache.Set(question, answer)
+	}
+
+	return nil
+}
+
+func (c *cacheConn) LocalAddr() net.Addr {
+	if c.realConn == nil {
+		return nil
+	}
+	return c.realConn.LocalAddr()
+}
+
+func (c *cacheConn) RemoteAddr() net.Addr {
+	if c.realConn == nil {
+		return nil
+	}
+	return c.realConn.RemoteAddr()
+}
+
+func (c *cacheConn) SetDeadline(t time.Time) error {
+	if c.realConn == nil {
+		return nil
+	}
+	return c.realConn.SetDeadline(t)
+}
+
+func (c *cacheConn) SetReadDeadline(t time.Time) error {
+	if c.realConn == nil {
+		return nil
+	}
+	return c.realConn.SetReadDeadline(t)
+}
+
+func (c *cacheConn) SetWriteDeadline(t time.Time) error {
+	if c.realConn == nil {
+		return nil
+	}
+	return c.realConn.SetWriteDeadline(t)
+}
+
+// capture runs errFunc and assigns the error, if any, to *errPtr.
+// Preserves the original error by wrapping with errors.Join if
+// errFunc returns a non-nil error.
+func capture(errPtr *error, errFunc func() error, msg string) {
+	err := errFunc()
+	if err == nil {
+		return
+	}
+	*errPtr = errors.Join(*errPtr, fmt.Errorf("%s: %w", msg, err))
+}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/jschaf/dns
 
-go 1.24.0
+go 1.24.1
 
 require golang.org/x/net v0.37.0

--- a/question_cache.go
+++ b/question_cache.go
@@ -1,8 +1,10 @@
 package dns
 
 import (
+	"fmt"
 	"net/netip"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/net/dns/dnsmessage"
@@ -14,13 +16,20 @@ type QuestionCache interface {
 	Set(q Question, a Answer)
 }
 
+// Question is a DNS question. This is a simplified representation of
+// dnsmessage.Question.
 type Question struct {
-	// Host is the fully qualified domain name with a trailing dot,
+	// FQDN is the fully qualified domain name with a trailing dot,
 	// e.g. "example.com.".
-	Host string
+	FQDN string
 	// Type is the type of question. Must be either dnsmessage.TypeA or
 	// dnsmessage.TypeAAAA.
 	Type dnsmessage.Type
+}
+
+// newQuestion creates a new Question from a dnsmessage.Question.
+func newQuestion(q dnsmessage.Question) Question {
+	return Question{FQDN: q.Name.String(), Type: q.Type}
 }
 
 // Answer is the DNS answer for a Question. This is a simplified representation
@@ -34,11 +43,60 @@ type Answer struct {
 	IPs []netip.Addr
 }
 
+func newAnswer(m *dnsmessage.Message) (Answer, error) {
+	if len(m.Answers) == 0 {
+		return Answer{}, fmt.Errorf("no answers in DNS message")
+	}
+	a := Answer{
+		FetchTime: time.Now(),
+		TTL:       time.Duration(m.Answers[0].Header.TTL) * time.Second,
+		IPs:       make([]netip.Addr, 0, len(m.Answers)),
+	}
+	for _, r := range m.Answers {
+		//nolint:exhaustive
+		switch r.Header.Type {
+		case dnsmessage.TypeA:
+			res, ok := r.Body.(*dnsmessage.AResource)
+			if !ok {
+				return Answer{}, fmt.Errorf("invalid A record body: %v", r.Body)
+			}
+			a.IPs = append(a.IPs, netip.AddrFrom4(res.A))
+		case dnsmessage.TypeAAAA:
+			res, ok := r.Body.(*dnsmessage.AAAAResource)
+			if !ok {
+				return Answer{}, fmt.Errorf("invalid AAAA record body: %v", r.Body)
+			}
+			a.IPs = append(a.IPs, netip.AddrFrom16(res.AAAA))
+		default:
+			return Answer{}, fmt.Errorf("unsupported record type: %v", r.Header.Type)
+		}
+	}
+	return a, nil
+}
+
+func (a Answer) IsExpired() bool {
+	return a.FetchTime.Add(a.TTL).Before(time.Now())
+}
+
+func (a Answer) GoString() string {
+	return fmt.Sprintf("Answer{FetchTime: %s, TTL: %ds, IPs: %v}", a.FetchTime.Format(time.DateTime), int(a.TTL.Seconds()), a.IPs)
+}
+
 var _ QuestionCache = &questionCache{}
 
 type questionCache struct {
-	m  map[Question]Answer
-	mu sync.RWMutex
+	m      map[Question]Answer
+	mu     sync.RWMutex
+	hits   *atomic.Int64
+	misses *atomic.Int64
+}
+
+func newQuestionCache() *questionCache {
+	return &questionCache{
+		m:      make(map[Question]Answer),
+		hits:   new(atomic.Int64),
+		misses: new(atomic.Int64),
+	}
 }
 
 func (c *questionCache) Get(q Question) (Answer, bool) {
@@ -47,23 +105,23 @@ func (c *questionCache) Get(q Question) (Answer, bool) {
 	c.mu.RUnlock()
 
 	if !ok {
+		c.misses.Add(1)
 		return Answer{}, false
 	}
-	expireTime := a.FetchTime.Add(a.TTL)
-	if expireTime.After(time.Now()) {
+
+	if a.IsExpired() {
 		c.mu.Lock()
 		delete(c.m, q)
 		c.mu.Unlock()
+		c.misses.Add(1)
 		return Answer{}, false
 	}
+
+	c.hits.Add(1)
 	return a, true
 }
 
 func (c *questionCache) Set(q Question, a Answer) {
-	// Skip if already expired.
-	if a.FetchTime.Add(a.TTL).Before(time.Now()) {
-		return
-	}
 	c.mu.Lock()
 	c.m[q] = a
 	c.mu.Unlock()

--- a/question_cache_test.go
+++ b/question_cache_test.go
@@ -1,0 +1,61 @@
+package dns
+
+import (
+	"net/netip"
+	"testing"
+	"time"
+
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+func TestQuestionCache_Get(t *testing.T) {
+	qc := newQuestionCache()
+
+	q1 := Question{FQDN: "example.com.", Type: dnsmessage.TypeA}
+	a1 := Answer{
+		FetchTime: time.Now(),
+		TTL:       20 * time.Millisecond,
+		IPs:       []netip.Addr{netip.MustParseAddr("1.2.3.4")},
+	}
+
+	// No cache entry.
+	if got, ok := qc.Get(q1); ok {
+		t.Errorf("empty question: got = %v; want false", got)
+	}
+	assertHitsMisses(t, qc, 0, 1)
+
+	// Set and get cache entry.
+	qc.Set(q1, a1)
+	if got, ok := qc.Get(q1); !ok {
+		t.Errorf("set question: got = %v, %v; want %v, true", got, ok, a1)
+	} else {
+		assertSameAnswer(t, a1, got)
+	}
+	assertHitsMisses(t, qc, 1, 1)
+
+	// Expired cache entry.
+	time.Sleep(a1.TTL)
+	if got, ok := qc.Get(q1); ok {
+		t.Errorf("expired question: got = %v; want false", got)
+	}
+	assertHitsMisses(t, qc, 1, 2)
+}
+
+func assertSameAnswer(t *testing.T, want, got Answer) {
+	t.Helper()
+	wantStr := want.GoString()
+	gotStr := got.GoString()
+	if wantStr != gotStr {
+		t.Errorf("answer mismatch\nwant: %s\ngot:  %s", wantStr, gotStr)
+	}
+}
+
+func assertHitsMisses(t *testing.T, qc *questionCache, wantHits, wantMisses int64) {
+	t.Helper()
+	if got := qc.hits.Load(); got != wantHits {
+		t.Errorf("hits: want %d, got %d", got, wantHits)
+	}
+	if got := qc.misses.Load(); got != wantMisses {
+		t.Errorf("misses: got = %d; want %d", got, wantMisses)
+	}
+}

--- a/testing.go
+++ b/testing.go
@@ -1,0 +1,236 @@
+package dns
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httptrace"
+	"net/netip"
+	"slices"
+	"testing"
+	"time"
+
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+const wantBody = "ok - test cache"
+
+type httpServer struct {
+	IP   netip.Addr
+	Port string
+	// FQDN is the fully qualified domain name of the test server.
+	FQDN string
+	URI  string
+}
+
+// startServers starts a test HTTP server and a fake DNS server. Adds a
+// DNS A record for host with the IP address of the test HTTP server.
+func startServers(t *testing.T, host string) (httpServer, *dnsServer) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(wantBody))
+	}))
+	t.Cleanup(server.Close)
+	httpHost, httpPort, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("net.SplitHostPort: %v", err)
+	}
+	ip, err := netip.ParseAddr(httpHost)
+	if err != nil {
+		t.Fatalf("netip.ParseAddr: %v", err)
+	}
+
+	h := httpServer{
+		IP:   ip,
+		Port: httpPort,
+		FQDN: host + ".",
+		URI:  fmt.Sprintf("http://%s:%s", host, httpPort),
+	}
+	d := startDNSServer(t, h.FQDN, h.IP)
+	return h, d
+}
+
+// doGetRequest sends a GET request to the test server and checks for a
+// successful response.
+func doGetRequest(ctx context.Context, client *http.Client, uri string) (mErr error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return fmt.Errorf("build get request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("do request: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("expected status %d, got %d", http.StatusOK, resp.StatusCode)
+	}
+	gotBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response body: %w", err)
+	}
+	defer capture(&mErr, resp.Body.Close, "close response body")
+	if string(gotBody) != wantBody {
+		return fmt.Errorf("got body %q, want %q", string(gotBody), wantBody)
+	}
+	return nil
+}
+
+// captureResolvedAddrs returns a new context that captures the resolved IP
+// addresses using httptrace.ClientTrace.
+func captureResolvedAddrs(t *testing.T, ctx context.Context) (context.Context, func() []netip.Addr) {
+	t.Helper()
+	var dnsDoneInfo httptrace.DNSDoneInfo
+	ctx = httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) {
+			t.Logf("got_conn: remote_addr=%v reused=%v", info.Conn.RemoteAddr().String(), info.Reused)
+		},
+		DNSStart: func(info httptrace.DNSStartInfo) {
+			t.Logf("dns_start: host=%s", info.Host)
+		},
+		DNSDone: func(info httptrace.DNSDoneInfo) {
+			t.Logf("dns_done: addrs=%v", info.Addrs)
+			dnsDoneInfo = info
+		},
+		ConnectStart: func(network, addr string) {
+			t.Logf("connect_start: network=%s, addr=%s", network, addr)
+		},
+		ConnectDone: func(network, addr string, err error) {
+			t.Logf("connect_done:  network=%s, addr=%s, err=%v", network, addr, err)
+		},
+	})
+	return ctx, func() []netip.Addr {
+		if dnsDoneInfo.Err != nil {
+			t.Fatalf("DNSDoneInfo.Err: %v", dnsDoneInfo.Err)
+		}
+		ips := make([]netip.Addr, 0, len(dnsDoneInfo.Addrs))
+		for _, a := range dnsDoneInfo.Addrs {
+			ip, err := netip.ParseAddr(a.String())
+			if err != nil {
+				t.Fatalf("netip.ParseAddr: %v", err)
+			}
+			ips = append(ips, ip)
+		}
+		return ips
+	}
+}
+
+// startDNSServer returns a fake DNS server that responds to A record queries
+// for host with the given IP address.
+func startDNSServer(t *testing.T, fqdnHost string, ip netip.Addr) *dnsServer {
+	fakeDNS := &dnsServer{
+		t: t,
+		handler: func(network string, q dnsmessage.Message) (dnsmessage.Message, error) {
+			r := dnsmessage.Message{
+				Header: dnsmessage.Header{
+					ID:       q.Header.ID,
+					Response: true,
+					RCode:    dnsmessage.RCodeSuccess,
+				},
+				Questions: q.Questions,
+			}
+			fqdn := dnsmessage.MustNewName(fqdnHost)
+			if len(q.Questions) == 1 &&
+				q.Questions[0].Type == dnsmessage.TypeA &&
+				q.Questions[0].Class == dnsmessage.ClassINET &&
+				fqdn == q.Questions[0].Name {
+				r.Answers = []dnsmessage.Resource{
+					{
+						Header: dnsmessage.ResourceHeader{
+							Name:   q.Questions[0].Name,
+							Type:   dnsmessage.TypeA,
+							Class:  dnsmessage.ClassINET,
+							Length: 4,
+						},
+						Body: &dnsmessage.AResource{
+							A: ip.As4(),
+						},
+					},
+				}
+			}
+
+			return r, nil
+		},
+	}
+	return fakeDNS
+}
+
+type dnsServer struct {
+	t       *testing.T
+	handler func(network string, q dnsmessage.Message) (dnsmessage.Message, error)
+}
+
+func (s *dnsServer) DialContext(_ context.Context, network, _ string) (net.Conn, error) {
+	s.t.Logf("dial fake dns server network %s", network) // addr is ignored
+	return &fakeDNSConn{server: s, network: network}, nil
+}
+
+type fakeDNSConn struct {
+	net.Conn
+	tcp      bool
+	server   *dnsServer
+	network  string
+	question dnsmessage.Message
+	buf      []byte
+}
+
+func (f *fakeDNSConn) Read(b []byte) (int, error) {
+	if len(f.buf) > 0 {
+		n := copy(b, f.buf)
+		f.buf = f.buf[n:]
+		return n, nil
+	}
+
+	resp, err := f.server.handler(f.network, f.question)
+	if err != nil {
+		return 0, err
+	}
+
+	bb := make([]byte, 2, 514)
+	bb, err = resp.AppendPack(bb)
+	if err != nil {
+		return 0, fmt.Errorf("cannot marshal DNS message: %w", err)
+	}
+
+	if f.tcp {
+		l := len(bb) - 2
+		bb[0] = byte(l >> 8)
+		bb[1] = byte(l)
+		f.buf = bb
+		return f.Read(b)
+	}
+
+	bb = bb[2:]
+	if len(b) < len(bb) {
+		return 0, errors.New("read would fragment DNS message")
+	}
+
+	copy(b, bb)
+	return len(bb), nil
+}
+
+func (f *fakeDNSConn) Write(b []byte) (int, error) {
+	if f.tcp && len(b) >= 2 {
+		b = b[2:]
+	}
+	if f.question.Unpack(b) != nil {
+		return 0, fmt.Errorf("cannot unmarshal DNS message fake %s (%d)", f.network, len(b))
+	}
+	return len(b), nil
+}
+
+func (f *fakeDNSConn) Close() error                { return nil }
+func (f *fakeDNSConn) SetDeadline(time.Time) error { return nil }
+
+func cmpNetIP(a, b netip.Addr) int { return a.Compare(b) }
+
+// assertSameAddrs checks that want and got contain the same IP addresses.
+func assertSameAddrs(t *testing.T, want []netip.Addr, got []netip.Addr) {
+	slices.SortFunc(want, cmpNetIP)
+	slices.SortFunc(got, cmpNetIP)
+	if len(want) != len(got) {
+		t.Fatalf("want %d addresses, got %d\nwant: %v\ngot:  %v", len(want), len(got), want, got)
+	}
+}


### PR DESCRIPTION
Since the extension point is a dialer function, we implement a custom dialer that returns a caching net.Conn. In the conn, we need to parse the DNS messages to build the cache key of the FQDN and DNS record type, either A or AAAA.

On the read, call we copy the results into a buffer and parse the DNS answer on Close. For UDP, we should only have a single Read call. If we do add TCP support, we could have multiple Read calls.

Skip TCP support for now because it's rare--users need to set a custom option in /etc/resolv.conf, either use-vc, usevc, or tcp. TCP support is tricky because we need to handle the 2-byte length prefix and the Go lookup code checks if the conn implements net.PacketConn to determine how to read from the conn.